### PR TITLE
Add HTTP service which redirects to HTTPS

### DIFF
--- a/templates/c2s/0/docker-compose.yml
+++ b/templates/c2s/0/docker-compose.yml
@@ -24,10 +24,14 @@ services:
       io.rancher.container.create_agent: 'true'
       io.rancher.scheduler.global: 'true'
 
+  http-https-redirect:
+    image: jamessharp/docker-nginx-https-redirect
+    labels:
+      io.rancher.scheduler.global: 'true'
+
   nearby-services-api:
     image: "nhsuk/nearby-services-api:${nearbyservices_docker_image_tag}"
     environment:
       NODE_ENV: production
       SPLUNK_HEC_ENDPOINT: ${splunk_hec_endpoint}
       SPLUNK_HEC_TOKEN: ${splunk_hec_token}
-

--- a/templates/c2s/0/rancher-compose.yml
+++ b/templates/c2s/0/rancher-compose.yml
@@ -86,9 +86,9 @@ lb:
       path: ''
       priority: 1
       protocol: http
-      service: c2s-frontend
+      service: http-https-redirect
       source_port: 80
-      target_port: 3000
+      target_port: 80
     - hostname: ''
       priority: 2
       protocol: https


### PR DESCRIPTION
As the c2s frontend doesn't handle the redirect to HTTPS, we add another
service which the load balancers forwards HTTP requests to. This service
simply sends a 301 redirect to the HTTPS version of the request.