### PR TITLE
:octopus: Changes required for CI scripts

### DIFF
--- a/templates/c2s-pharmacy-finder/0/docker-compose.yml
+++ b/templates/c2s-pharmacy-finder/0/docker-compose.yml
@@ -31,3 +31,13 @@ services:
       traefik.domain: ${traefik_domain}
       traefik.port: 3001
       io.rancher.container.pull_image: always
+    links:
+    - mongodb-pharmacy:mongo
+
+  mongodb-pharmacy:
+    image: "nhsuk/mongodb-pharmacy:${mongodb_pharmacy_docker_image_tag}"
+    labels:
+      traefik.enable: true
+      traefik.domain: ${traefik_domain}
+      traefik.port: 27017
+      io.rancher.container.pull_image: always

--- a/templates/c2s-pharmacy-finder/0/docker-compose.yml
+++ b/templates/c2s-pharmacy-finder/0/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     - mongodb-pharmacy:mongo
 
   mongodb-pharmacy:
-    image: "nhsuk/mongodb-pharmacy:${mongodb_pharmacy_docker_image_tag}"
+    image: "nhsuk/pharmacy-db:${pharmacy_db_docker_image_tag}"
     labels:
       traefik.enable: true
       traefik.domain: ${traefik_domain}

--- a/templates/c2s-pharmacy-finder/0/docker-compose.yml
+++ b/templates/c2s-pharmacy-finder/0/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
 
   c2s-frontend:
-    image: "nhsuk/connecting-to-services:${c2s_docker_image_tag}"
+    image: "nhsuk/connecting-to-services:${connecting_to_services_docker_image_tag}"
     environment:
       NODE_ENV: production
       SPLUNK_HEC_ENDPOINT: ${splunk_hec_endpoint}
@@ -21,7 +21,7 @@ services:
     - nearby-services-api:nearby-services-api
 
   nearby-services-api:
-    image: "nhsuk/nearby-services-api:${nearbyservices_docker_image_tag}"
+    image: "nhsuk/nearby-services-api:${nearby_services_api_docker_image_tag}"
     environment:
       NODE_ENV: production
       SPLUNK_HEC_ENDPOINT: ${splunk_hec_endpoint}

--- a/templates/c2s-pharmacy-finder/0/rancher-compose.yml
+++ b/templates/c2s-pharmacy-finder/0/rancher-compose.yml
@@ -74,3 +74,17 @@ nearby-services-api:
     request_line: GET "/nearby?latitude=53.800755&longitude=-1.549077" "HTTP/1.0"
     reinitializing_timeout: 60000
   start_on_create: true
+
+mongodb-pharmacy:
+  scale: 1
+  health_check:
+    response_timeout: 60000
+    healthy_threshold: 2
+    port: 27017
+    unhealthy_threshold: 3
+    initializing_timeout: 60000
+    interval: 20000
+    strategy: recreate
+    request_line: ''
+    reinitializing_timeout: 60000
+  start_on_create: true

--- a/templates/c2s-pharmacy-finder/0/rancher-compose.yml
+++ b/templates/c2s-pharmacy-finder/0/rancher-compose.yml
@@ -1,3 +1,5 @@
+version: '2'
+
 catalog:
   name: nhsuk_c2s
   version: 1.0.0
@@ -53,44 +55,45 @@ catalog:
       default: "dcs222rfg0jh2hpdaqwc2gmki_9r4q"
       type: "string"
 
-c2s-frontend:
-  scale: 1
-  start_on_create: true
-  health_check:
-    response_timeout: 5000
-    healthy_threshold: 2
-    port: 3000
-    unhealthy_threshold: 3
-    initializing_timeout: 60000
-    interval: 5000
-    strategy: recreate
-    request_line: GET "/finders/find-help" "HTTP/1.0"
-    reinitializing_timeout: 60000
+services:
+  c2s-frontend:
+    scale: 1
+    start_on_create: true
+    health_check:
+      response_timeout: 5000
+      healthy_threshold: 2
+      port: 3000
+      unhealthy_threshold: 3
+      initializing_timeout: 60000
+      interval: 5000
+      strategy: recreate
+      request_line: GET "/finders/find-help" "HTTP/1.0"
+      reinitializing_timeout: 60000
 
-nearby-services-api:
-  scale: 1
-  health_check:
-    response_timeout: 60000
-    healthy_threshold: 2
-    port: 3001
-    unhealthy_threshold: 3
-    initializing_timeout: 60000
-    interval: 20000
-    strategy: recreate
-    request_line: GET "/nearby?latitude=53.800755&longitude=-1.549077" "HTTP/1.0"
-    reinitializing_timeout: 60000
-  start_on_create: true
+  nearby-services-api:
+    scale: 1
+    health_check:
+      response_timeout: 60000
+      healthy_threshold: 2
+      port: 3001
+      unhealthy_threshold: 3
+      initializing_timeout: 60000
+      interval: 20000
+      strategy: recreate
+      request_line: GET "/nearby?latitude=53.800755&longitude=-1.549077" "HTTP/1.0"
+      reinitializing_timeout: 60000
+    start_on_create: true
 
-mongodb-pharmacy:
-  scale: 1
-  health_check:
-    response_timeout: 60000
-    healthy_threshold: 2
-    port: 27017
-    unhealthy_threshold: 3
-    initializing_timeout: 60000
-    interval: 20000
-    strategy: recreate
-    request_line: ''
-    reinitializing_timeout: 60000
-  start_on_create: true
+  mongodb-pharmacy:
+    scale: 1
+    health_check:
+      response_timeout: 60000
+      healthy_threshold: 2
+      port: 27017
+      unhealthy_threshold: 3
+      initializing_timeout: 60000
+      interval: 20000
+      strategy: recreate
+      request_line: ''
+      reinitializing_timeout: 60000
+    start_on_create: true

--- a/templates/c2s-pharmacy-finder/0/rancher-compose.yml
+++ b/templates/c2s-pharmacy-finder/0/rancher-compose.yml
@@ -5,13 +5,13 @@ catalog:
     Connecting to Services (Using Rancher LB)
   minimum_rancher_version: v0.59.0
   questions:
-    - variable: "c2s_docker_image_tag"
+    - variable: "connecting_to_services_docker_image_tag"
       description: "c2s Docker image tag"
       label: "c2s Docker image tag:"
       required: true
       default: "latest"
       type: "string"
-    - variable: "nearbyservices_docker_image_tag"
+    - variable: "nearby_services_api_docker_image_tag"
       description: "nearby-services-api Docker image tag"
       label: "nearby-services-api Docker image tag:"
       required: true

--- a/templates/c2s-pharmacy-finder/0/rancher-compose.yml
+++ b/templates/c2s-pharmacy-finder/0/rancher-compose.yml
@@ -17,6 +17,12 @@ catalog:
       required: true
       default: "latest"
       type: "string"
+    - variable: "pharmacy_db_docker_image_tag"
+      description: "pharmacy_db Docker image tag"
+      label: "pharmacy_db Docker image tag:"
+      required: true
+      default: "latest"
+      type: "string"
     - variable: "splunk_hec_endpoint"
       description: "Splunk HTTP Event Collector URL"
       label: "Splunk HTTP Event Collector URL:"

--- a/templates/c2s-pharmacy-finder/2/docker-compose.yml
+++ b/templates/c2s-pharmacy-finder/2/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
 
   c2s-frontend:
-    image: "nhsuk/connecting-to-services:${c2s_docker_image_tag}"
+    image: "nhsuk/connecting-to-services:${connecting_to_services_docker_image_tag}"
     environment:
       NODE_ENV: production
       SPLUNK_HEC_ENDPOINT: ${splunk_hec_endpoint}
@@ -22,7 +22,7 @@ services:
     - nearby-services-api:nearby-services-api
 
   nearby-services-api:
-    image: "nhsuk/nearby-services-api:${nearbyservices_docker_image_tag}"
+    image: "nhsuk/nearby-services-api:${nearby_services_api_docker_image_tag}"
     environment:
       NODE_ENV: production
       SPLUNK_HEC_ENDPOINT: ${splunk_hec_endpoint}
@@ -37,7 +37,7 @@ services:
     - mongodb-pharmacy:mongo
 
   mongodb-pharmacy:
-    image: "nhsuk/mongodb-pharmacy:${mongodb_pharmacy_docker_image_tag}"
+    image: "nhsuk/mongodb-pharmacy:${pharmacy_db_docker_image_tag}"
     labels:
       traefik.enable: true
       traefik.domain: ${traefik_domain}

--- a/templates/c2s-pharmacy-finder/2/rancher-compose.yml
+++ b/templates/c2s-pharmacy-finder/2/rancher-compose.yml
@@ -7,21 +7,21 @@ catalog:
     Connecting to Services (Using Rancher LB)
   minimum_rancher_version: v0.59.0
   questions:
-    - variable: "c2s_docker_image_tag"
-      description: "c2s Docker image tag"
-      label: "c2s Docker image tag:"
+    - variable: "connecting_to_services_docker_image_tag"
+      description: "C2S docker image tag"
+      label: "C2S docker image tag:"
       required: true
       default: "latest"
       type: "string"
-    - variable: "nearbyservices_docker_image_tag"
-      description: "nearby-services-api Docker image tag"
-      label: "nearby-services-api Docker image tag:"
+    - variable: "nearby_services_api_docker_image_tag"
+      description: "Nearby Services API docker image tag"
+      label: "Nearby Services API docker image tag"
       required: true
       default: "latest"
       type: "string"
-    - variable: "mongodb_pharmacy_docker_image_tag"
-      description: "mongodb_pharmacy Docker image tag"
-      label: "mongodb_pharmacy Docker image tag:"
+    - variable: "pharmacy_db_docker_image_tag"
+      description: "Pharmacy DB Docker image tag"
+      label: "Pharmacy DB Docker image tag"
       required: true
       default: "latest"
       type: "string"


### PR DESCRIPTION
The CI scripts need to build an answers file for use with the `rancher
up` command and only have the repo names available.

The paramater names have been changed to match the repo names.