### PR TITLE
Splunk template

### DIFF
--- a/infra-templates/splunk-forwarder/0/docker-compose.yml
+++ b/infra-templates/splunk-forwarder/0/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '2'
+
+services:
+
+  splunk-uf:
+    image: nhsuk/rancher-splunk-uf
+    environment:
+      SPLUNK_START_ARGS: --accept-license --answer-yes
+      SPLUNK_USER: root
+      CACERT: ${CACERT}
+      CERT: ${CERT}
+      CERT_PASS: ${CERT_PASS}
+      INDEXER_HOST: ${INDEXER_HOST}
+      INDEXER_PORT: ${INDEXER_PORT}
+    volumes:
+    - /var/lib/docker/containers:/host/containers:ro
+    - /var/log:/docker/log:ro
+    - /var/run/docker.sock:/var/run/docker.sock:ro
+    labels:
+      io.rancher.container.pull_image: always
+      io.rancher.scheduler.global: true
+    network_mode: host
+    privileged: true

--- a/infra-templates/splunk-forwarder/0/rancher-compose.yml
+++ b/infra-templates/splunk-forwarder/0/rancher-compose.yml
@@ -1,0 +1,29 @@
+version: '2'
+
+catalog:
+  name: nhsuk_splunk_forwarder
+  version: 1.0.0
+  description: |
+    NHSuk - Splunk Forwarder
+  minimum_rancher_version: v0.59.0
+  questions:
+    - variable: "INDEXER_HOST"
+      label: "Indexer Host"
+      required: true
+      type: string
+    - variable: "INDEXER_PORT"
+      label: "Indexer Port"
+      required: true
+      type: int
+    - variable: "CACERT"
+      label: "CA Certificate"
+      required: true
+      type: multiline
+    - variable: "CERT"
+      label: "Certificate for forwarder"
+      required: true
+      type: multiline
+    - variable: "CERT_PASS"
+      label: "Certificate for forwarder password"
+      required: true
+      type: password

--- a/infra-templates/splunk-forwarder/config.yml
+++ b/infra-templates/splunk-forwarder/config.yml
@@ -1,0 +1,5 @@
+name: Splunk Forwarder
+description: |
+  Splunk forwarder
+version: 1.0.0
+category: nhsuk beta splunk-forwarder


### PR DESCRIPTION
This template runs a Splunk forwarder on every host, which forwards the container logs and `docker inspect` output to `splunk-collector.cloudapp.net` which in turn forwards to `splunk.nhschoices.net`