### PR TITLE
:raised_hand: Update service name to match docker repo

### DIFF
--- a/templates/c2s-pharmacy-finder/2/docker-compose.yml
+++ b/templates/c2s-pharmacy-finder/2/docker-compose.yml
@@ -30,10 +30,10 @@ services:
       io.rancher.container.pull_image: always
       io.rancher.scheduler.affinity:host_label_soft: c2s=true
     links:
-    - mongodb-pharmacy:mongo
+    - pharmacy-db:mongo
 
-  mongodb-pharmacy:
-    image: "nhsuk/mongodb-pharmacy:${PHARMACY_DB_DOCKER_IMAGE_TAG}"
+  pharmacy-db:
+    image: "nhsuk/pharmacy-db:${PHARMACY_DB_DOCKER_IMAGE_TAG}"
     labels:
       io.rancher.container.pull_image: always
       io.rancher.scheduler.affinity:host_label_soft: c2s=true

--- a/templates/c2s-pharmacy-finder/2/rancher-compose.yml
+++ b/templates/c2s-pharmacy-finder/2/rancher-compose.yml
@@ -79,7 +79,7 @@ services:
       reinitializing_timeout: 60000
     start_on_create: true
 
-  mongodb-pharmacy:
+  pharmacy-db:
     scale: 1
     health_check:
       response_timeout: 60000


### PR DESCRIPTION
This update brings the templates inline with the docker hub repo and github repo name changes that happened a while back. See nhsuk/pharmacy-db#5 for more details
If this is good to merge the docker hub repo https://hub.docker.com/r/nhsuk/mongodb-pharmacy/ should be deleted