### PR TITLE
Share the /wagtail/static directory between containers

### DIFF
--- a/templates/content-platform/0/docker-compose.yml
+++ b/templates/content-platform/0/docker-compose.yml
@@ -1,5 +1,9 @@
 version: '2'
 
+volumes:
+  static:
+
+
 services:
 
   nginx:
@@ -15,6 +19,8 @@ services:
       traefik.domain: ${TRAEFIK_DOMAIN}
       traefik.port: 80
       io.rancher.container.pull_image: always
+    volumes:
+      - static:/wagtail/static
 
   wagtail:
     image: nhsuk/content-platform:${CONTENT_PLATFORM_DOCKER_IMAGE_TAG}
@@ -38,3 +44,5 @@ services:
       AZURE_AD_CLIENT_KEY: ${AZURE_AD_CLIENT_KEY}
     labels:
       io.rancher.container.pull_image: always
+    volumes:
+      - static:/wagtail/static

--- a/templates/content-platform/0/docker-compose.yml
+++ b/templates/content-platform/0/docker-compose.yml
@@ -19,8 +19,9 @@ services:
       traefik.domain: ${TRAEFIK_DOMAIN}
       traefik.port: 80
       io.rancher.container.pull_image: always
+      io.rancher.container.pull_image: always
     volumes:
-      - static:/wagtail/static
+      - content-platform-static:/wagtail/static
 
   wagtail:
     image: nhsuk/content-platform:${CONTENT_PLATFORM_DOCKER_IMAGE_TAG}
@@ -44,5 +45,6 @@ services:
       AZURE_AD_CLIENT_KEY: ${AZURE_AD_CLIENT_KEY}
     labels:
       io.rancher.container.pull_image: always
+      io.rancher.sidekicks: nginx
     volumes:
-      - static:/wagtail/static
+      - content-platform-static:/wagtail/static


### PR DESCRIPTION
We will run into more problems having two different environments creating their own static files. These static files need to be __identical__ for everything to work properly.
Therefore we want the `wagtail` container to generate static content and the `nginx` container to serve it via a shared volume